### PR TITLE
Fix Issue #79 rules to regular expressions: fix domain dots matching any character and fix treating the end of a rule as regex asterisk

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -114,10 +114,11 @@ function getRegExForRule(rule: string) {
             reParts.push(".*");
         else
             reParts.push(part);
-        reParts.push(".");
+        reParts.push("\\.");
     }
     if (reParts[reParts.length - 1] === ".")
         reParts.pop();
+    reParts.push("$");
     return new RegExp(reParts.join(""));
 }
 


### PR DESCRIPTION
Fix Issue #79  
_"Invalid rule matching. (Matching end of string and escaping special characters especially the dot.)"_  